### PR TITLE
update links in docs, test pyimport also on arm64

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -78,9 +78,9 @@ lst=Dataverse.file_list(doi)
 
 ## Argo via Python API
 
-The python library called [argopy](https://img.shields.io/readthedocs/argopy?logo=readthedocs) provides more ways to access, manipulate, and visualize [Argo data](https://argopy.readthedocs.io/en/latest/what_is_argo.html#what-is-argo). The notebook below demonstrates how you can : 
+The python library called [argopy](https://github.com/euroargodev/argopy#readme) provides more ways to access, manipulate, and visualize [Argo data](https://argopy.readthedocs.io/en/latest/what_is_argo.html#what-is-argo). The notebook below demonstrates how you can : 
 
-1. install `argopy` into `Julia` via [Conda.jl](https://github.com/JuliaPy/Conda.jl)
-2. use `argopy` from Julia via [PyCall.jl](https://github.com/JuliaPy/PyCall.jl)
+1. install `argopy` into `Julia` via [Conda.jl](https://github.com/JuliaPy/Conda.jl#readme)
+2. use `argopy` from Julia via [PyCall.jl](https://github.com/JuliaPy/PyCall.jl#readme)
 
-👉 [Notebook](http://gaelforget.net/notebooks/Argo_argopy.html) 👈 [(code)](https://raw.githubusercontent.com/euroargodev/ArgoData.jl/master/examples/Argo_argopy.jl)
+👉 [Notebook](../Argo_argopy.html) 👈 [(code)](https://raw.githubusercontent.com/euroargodev/ArgoData.jl/master/examples/Argo_argopy.jl)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,12 @@ using Climatology, MITgcm
 ENV["DATADEPS_ALWAYS_ACCEPT"]=true
 Climatology.MITPROFclim_download()
 
-if Sys.ARCH!==:aarch64
-  if false #external python path
+run_argopy=true
+#Sys.ARCH==:aarch64 ? run_argopy=false : nothing
+
+if run_argopy
+  method="internal"
+  if method=="external"
     tmpfile=joinpath(tempdir(),"pythonpath.txt")
     run(pipeline(`which python`,tmpfile)) 
     ENV["PYTHON"]=readline(tmpfile)


### PR DESCRIPTION
notes : 

- while the Conda + PyCall sequence , the pyimport'ed argopy fails on arm64 **does not work**
- the notebook that is now again [built in the docs](https://euroargodev.github.io/ArgoData.jl/dev/Argo_argopy.html), returns an error -- compare to the [last version that worked as expected](https://gaelforget.net/notebooks/Argo_argopy.html)